### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/symposium-dev/symposium-cargo/compare/v0.2.0...v0.3.0) - 2026-03-19
+
+### Other
+
+- Only run CI on pushes to main
+- Upgrade sacp
+- (untested) add ci and release-plz github actions
+- Make binary be able to serve mcp server
+- Run subagent after cargo test fail
+- Review comments
+- Auto prompt when project fails to build
+- Add set_cwd tool so subsequent calls don't need to pass a cwd
+- Add more cargo tools
+- Add cargo add

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "symposium-cargo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "elizacp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-cargo"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT or Apache-2.0"
 description = "Symposium Cargo proxy - an MCP server connecting to Cargo and a ACP Proxy managing it"


### PR DESCRIPTION



## 🤖 New release

* `symposium-cargo`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `symposium-cargo` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  symposium_cargo::cargo_mcp::build_mcp_server now takes 1 parameters instead of 0, in /tmp/.tmpVRBIf6/symposium-cargo/src/cargo_mcp.rs:81
  symposium_cargo::build_mcp_server now takes 1 parameters instead of 0, in /tmp/.tmpVRBIf6/symposium-cargo/src/cargo_mcp.rs:81

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types (e.g. via turbofish syntax) will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function build_mcp_server (0 -> 1 generic types) in /tmp/.tmpVRBIf6/symposium-cargo/src/cargo_mcp.rs:81
  function build_mcp_server (0 -> 1 generic types) in /tmp/.tmpVRBIf6/symposium-cargo/src/cargo_mcp.rs:81

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct CargoProxy in /tmp/.tmpVRBIf6/symposium-cargo/src/lib.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/symposium-dev/symposium-cargo/compare/v0.2.0...v0.3.0) - 2026-03-19

### Other

- Only run CI on pushes to main
- Upgrade sacp
- (untested) add ci and release-plz github actions
- Make binary be able to serve mcp server
- Run subagent after cargo test fail
- Review comments
- Auto prompt when project fails to build
- Add set_cwd tool so subsequent calls don't need to pass a cwd
- Add more cargo tools
- Add cargo add
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).